### PR TITLE
Add all authors to title slide

### DIFF
--- a/content/introduction.html
+++ b/content/introduction.html
@@ -5,6 +5,8 @@
         <img class="plain" src="images/GeoExt-logo.png" style="background: none;" />
 
         #### by Seth Girvin, [Compass Informatics](https://compass.ie/)
+        #### Christian Mayer, [meggsimum](https://meggsimum.de/)
+        #### Marc Jansen, [terrestris](https://terrestris.de/)
 
     </script>
 </section>
@@ -116,4 +118,3 @@
         </aside>
     </script>
 </section>
-


### PR DESCRIPTION
This adds all co-authors to the title slides. If you don't like it because @marcjansen and me are not physically there ignore this PR.